### PR TITLE
Change the default line break mode to WordWrap to align with MAUI Label control

### DIFF
--- a/src/Indiko.Maui.Controls.SelectableLabel/SelectableLabel.cs
+++ b/src/Indiko.Maui.Controls.SelectableLabel/SelectableLabel.cs
@@ -48,7 +48,7 @@ public class SelectableLabel : View
         set => SetValue(FontFamilyProperty, value);
     }
 
-    public static readonly BindableProperty LineBreakModeProperty = BindableProperty.Create(nameof(LineBreakMode), typeof(LineBreakMode), typeof(SelectableLabel), LineBreakMode.TailTruncation);
+    public static readonly BindableProperty LineBreakModeProperty = BindableProperty.Create(nameof(LineBreakMode), typeof(LineBreakMode), typeof(SelectableLabel), LineBreakMode.WordWrap);
     public LineBreakMode LineBreakMode
     {
         get => (LineBreakMode)GetValue(LineBreakModeProperty);


### PR DESCRIPTION
To ensure consistent behavior, SelectableLabel should use the same default line break mode as the MAUI Label control: LineBreakMode.WordWrap. This makes it easier to replace a Label with a SelectableLabel without introducing unintended layout changes.